### PR TITLE
Fix for GRPCStatus

### DIFF
--- a/passes/wraperr/testdata/src/a/a.go
+++ b/passes/wraperr/testdata/src/a/a.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"cloud.google.com/go/spanner"
+	"google.golang.org/grpc/status"
 )
 
 type wrapErr struct {
@@ -55,6 +56,37 @@ func f4(ctx context.Context, client *spanner.Client) {
 			return func() error {
 				return &wrapErr{err}
 			}() // want "must not be wrapped"
+		}
+		return nil
+	})
+}
+
+type grpcStatusErr struct {
+	error
+}
+
+// see: https://github.com/googleapis/google-cloud-go/issues/1223
+func (*grpcStatusErr) GRPCStatus() *status.Status {
+	return nil
+}
+
+func f5(ctx context.Context, client *spanner.Client) {
+	client.ReadWriteTransaction(ctx, func(ctx context.Context, txn *spanner.ReadWriteTransaction) error {
+		stmt := spanner.Statement{SQL: `SELECT 1`}
+		_, err := client.Single().Query(ctx, stmt).Next()
+		if err != nil {
+			return &grpcStatusErr{err} // OK
+		}
+		return nil
+	})
+}
+
+func f6(ctx context.Context, client *spanner.Client) {
+	client.ReadWriteTransaction(ctx, func(ctx context.Context, txn *spanner.ReadWriteTransaction) error {
+		stmt := spanner.Statement{SQL: `SELECT 1`}
+		_, err := client.Single().Query(ctx, stmt).Next()
+		if err != nil {
+			return &spanner.Error{} // OK
 		}
 		return nil
 	})

--- a/passes/wraperr/testdata/src/a/go.mod
+++ b/passes/wraperr/testdata/src/a/go.mod
@@ -2,4 +2,7 @@ module a
 
 go 1.12
 
-require cloud.google.com/go v0.37.1
+require (
+	cloud.google.com/go v0.37.1
+	google.golang.org/grpc v1.19.0
+)

--- a/passes/wraperr/testdata/src/a/vendor/modules.txt
+++ b/passes/wraperr/testdata/src/a/vendor/modules.txt
@@ -80,13 +80,13 @@ google.golang.org/appengine/internal/urlfetch
 # google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19
 google.golang.org/genproto/googleapis/rpc/errdetails
 google.golang.org/genproto/googleapis/spanner/v1
-google.golang.org/genproto/googleapis/api/annotations
 google.golang.org/genproto/googleapis/rpc/status
+google.golang.org/genproto/googleapis/api/annotations
 # google.golang.org/grpc v1.19.0
+google.golang.org/grpc/status
 google.golang.org/grpc
 google.golang.org/grpc/codes
 google.golang.org/grpc/metadata
-google.golang.org/grpc/status
 google.golang.org/grpc/credentials
 google.golang.org/grpc/credentials/oauth
 google.golang.org/grpc/balancer


### PR DESCRIPTION
fixed: #20 

Ignore errors which implement `interface{GRPCStatus() *status.Status}`.
And zagane also ignores `*spanner.Error`.