### PR TITLE
Fix for BatchReadOnlyTransaction check

### DIFF
--- a/passes/unclosetx/testdata/src/a/a.go
+++ b/passes/unclosetx/testdata/src/a/a.go
@@ -73,3 +73,22 @@ func f6(ctx context.Context, client *spanner.Client) error {
 	}
 	return nil
 }
+
+func f7(ctx context.Context, client *spanner.Client) error {
+	ro, _ := client.BatchReadOnlyTransaction(ctx, spanner.StrongRead())
+	defer ro.Close()
+
+	stmt := spanner.Statement{SQL: `SELECT 1`}
+
+	iter := ro.Query(ctx, stmt)
+	defer iter.Stop()
+
+	for {
+		_, err := iter.Next()
+		if err != nil {
+			break
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
I have a weird case of using `BatchReadOnlyTransaction`, please check f7 testcase.

I guess the reason is `BatchReadOnlyTransaction.Close` and `ReadOnlyTransaction.Close` are different.
https://github.com/googleapis/google-cloud-go/blob/main/spanner/batch.go#L246-L251

So, I added BatchReadOnlyTransaction.Close to close method list.
(I don't have confidence on my changes.)